### PR TITLE
Keep the order defined in the YML lists

### DIFF
--- a/src/main/java/io/xstefank/wildfly/bot/TriagePullRequestProcessor.java
+++ b/src/main/java/io/xstefank/wildfly/bot/TriagePullRequestProcessor.java
@@ -14,8 +14,8 @@ import org.kohsuke.github.GHEventPayload;
 import org.kohsuke.github.GHPullRequest;
 
 import java.io.IOException;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.ArrayList;
+import java.util.List;
 
 @ApplicationScoped
 public class TriagePullRequestProcessor {
@@ -33,11 +33,11 @@ public class TriagePullRequestProcessor {
         }
 
         GHPullRequest pullRequest = pullRequestPayload.getPullRequest();
-        Set<String> mentions = new TreeSet<>();
+        List<String> mentions = new ArrayList<>();
 
         for (WildFlyRule rule : wildflyBotConfigFile.wildfly.rules) {
             if (Matcher.matches(pullRequest, rule)) {
-                 LOG.debugf("Pull Request %s was matched with a rule with the id: %s.", pullRequest.getTitle(), rule.id != null ? rule.id : "N/A");
+                LOG.debugf("Pull Request %s was matched with a rule with the id: %s.", pullRequest.getTitle(), rule.id != null ? rule.id : "N/A");
                 for (String nick : rule.notify) {
                     if (!nick.equals(pullRequest.getUser().getLogin())) {
                         mentions.add(nick);

--- a/src/main/java/io/xstefank/wildfly/bot/model/WildFlyConfigFile.java
+++ b/src/main/java/io/xstefank/wildfly/bot/model/WildFlyConfigFile.java
@@ -2,9 +2,8 @@ package io.xstefank.wildfly.bot.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 public class WildFlyConfigFile {
 
@@ -27,11 +26,11 @@ public class WildFlyConfigFile {
 
         public String titleBody;
 
-        @JsonDeserialize(as = TreeSet.class)
-        public Set<String> directories = new TreeSet<>();
+        @JsonDeserialize(as = ArrayList.class)
+        public List<String> directories = new ArrayList<>();
 
-        @JsonDeserialize(as = TreeSet.class)
-        public Set<String> notify = new TreeSet<>();
+        @JsonDeserialize(as = ArrayList.class)
+        public List<String> notify = new ArrayList<>();
 
         @Override
         public String toString() {

--- a/src/test/java/io/xstefank/wildfly/bot/PROpenedTest.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PROpenedTest.java
@@ -40,7 +40,7 @@ public class PROpenedTest {
             .event(GHEvent.PULL_REQUEST)
             .then().github(mocks -> {
                 Mockito.verify(mocks.pullRequest(1371642823))
-                    .comment("/cc @0979986727, @7125767235");
+                    .comment("/cc @7125767235, @0979986727");
                 GHRepository repo = mocks.repository("xstefank/wildfly");
                 Mockito.verify(repo).createCommitStatus("5db0f8e923d84fe05a60658ed5bb95f7aa23b66f",
                         GHCommitState.ERROR, "", "title-check: Wrong content of the title!", "Format");


### PR DESCRIPTION
TreeSet reorders defined list into ordered set by the name. We should really keep the ordering defined in the config.