### PR TITLE
Remove title and commit message pattern option from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,8 @@ wildfly:
    - body: "test"
      notify: [xstefank,petrberan]
  format:
-   title-check:
-     pattern: "\\[WFLY-\\d+\\]\\s+.*|WFLY-\\d+\\s+.*"
-     message: "Wrong content of the title!"
+   title:
+     message: "Wrong content of the PR title"
    description:
      regexes:
        - pattern: "JIRA:\\s+https://issues.redhat.com/browse/WFLY-\\d+|https://issues.redhat.com/browse/WFLY-\\d+"
@@ -101,14 +100,15 @@ wildfly:
    - user@acme.org
 ```
 
-1. `title-check`- Checks the title of a PR by using a regular expression in the `pattern` field.
-> The correct format in example is "[WFLY-11] Name"
+1. `title`- Checks the title of a PR by using a regular expression generated from `projectKey` field, which is by default "WFLY". You can find more information in [wildfly-bot-config-example.yml](wildfly-bot-config-example.yml)
 2. `description`- Checks comments of a PR by using individual regular expressions in the `pattern` fields under `regexes`.
 > The correct format in example is "https://issues.jboss.org/browse/WFLY-11"
 3. `commits-quantity`- Checks the amount of commits in PR with the amount in the `quantity` field.
 > In the field you can use the exact values '1', '2' or range '1-2', '2-4' up to 100.
 4. `message` - The text of an error message in the respective check.
 5. `emails` - List of emails to receive notifications.
+
+> **_NOTE:_**  `title` and `commit` are enabled by default. More [here](wildfly-bot-config-example.yml).
 
 Also, there is a possibility to select checks that you need. Just left in the `wildfly-bot.yml` file checks you need.
 
@@ -120,9 +120,8 @@ wildfly:
    - body: "test"
      notify: [xstefank,petrberan]
  format:
-   title-check:
-     pattern: "\\[WFLY-\\d+\\]\\s+.*|WFLY-\\d+\\s+.*"
-     message: "Wrong content of the title!"
+   title:
+     message: "Wrong content of the PR title"
  emails:
    - nonexisistingemail@whatever.com
    - whoever@nonexistingmailingservice.com

--- a/src/main/java/io/xstefank/wildfly/bot/PullRequestFormatProcessor.java
+++ b/src/main/java/io/xstefank/wildfly/bot/PullRequestFormatProcessor.java
@@ -8,6 +8,7 @@ import io.xstefank.wildfly.bot.format.CommitMessagesCheck;
 import io.xstefank.wildfly.bot.format.CommitsQuantityCheck;
 import io.xstefank.wildfly.bot.format.DescriptionCheck;
 import io.xstefank.wildfly.bot.format.TitleCheck;
+import io.xstefank.wildfly.bot.model.RegexDefinition;
 import io.xstefank.wildfly.bot.model.RuntimeConstants;
 import io.xstefank.wildfly.bot.model.WildFlyConfigFile;
 import io.xstefank.wildfly.bot.util.GithubCommitProcessor;
@@ -128,8 +129,12 @@ public class PullRequestFormatProcessor {
             return;
         }
 
-        if (wildflyConfigFile.wildfly.format.titleCheck != null) {
-            checks.add(new TitleCheck(wildflyConfigFile.wildfly.format.titleCheck));
+        if (wildflyConfigFile.wildfly.format.title.enabled) {
+            checks.add(new TitleCheck(new RegexDefinition(wildflyConfigFile.wildfly.getProjectPattern(), wildflyConfigFile.wildfly.format.title.message)));
+        }
+
+        if (wildflyConfigFile.wildfly.format.commit.enabled) {
+            checks.add(new CommitMessagesCheck(new RegexDefinition(wildflyConfigFile.wildfly.getProjectPattern(), wildflyConfigFile.wildfly.format.commit.message)));
         }
 
         if (wildflyConfigFile.wildfly.format.description != null) {
@@ -139,10 +144,6 @@ public class PullRequestFormatProcessor {
 
         if (wildflyConfigFile.wildfly.format.commitsQuantity != null) {
             checks.add(new CommitsQuantityCheck(wildflyConfigFile.wildfly.format.commitsQuantity));
-        }
-
-        if (wildflyConfigFile.wildfly.format.commitsMessage != null) {
-            checks.add(new CommitMessagesCheck(wildflyConfigFile.wildfly.format.commitsMessage));
         }
 
         initialized = true;

--- a/src/main/java/io/xstefank/wildfly/bot/format/CommitMessagesCheck.java
+++ b/src/main/java/io/xstefank/wildfly/bot/format/CommitMessagesCheck.java
@@ -10,8 +10,6 @@ import java.io.IOException;
 
 public class CommitMessagesCheck implements Check {
 
-    static final String DEFAULT_MESSAGE = "One of the commit messages has wrong format";
-
     private Pattern pattern;
     private String message;
 
@@ -20,7 +18,7 @@ public class CommitMessagesCheck implements Check {
             throw new IllegalArgumentException("Input argument cannot be null");
         }
         pattern = description.pattern;
-        message = (description.message != null) ? description.message : DEFAULT_MESSAGE;
+        message = description.message;
     }
 
     @Override
@@ -44,6 +42,6 @@ public class CommitMessagesCheck implements Check {
 
     @Override
     public String getName() {
-        return "commits-message";
+        return "commit";
     }
 }

--- a/src/main/java/io/xstefank/wildfly/bot/format/TitleCheck.java
+++ b/src/main/java/io/xstefank/wildfly/bot/format/TitleCheck.java
@@ -8,8 +8,6 @@ import java.util.regex.Pattern;
 
 public class TitleCheck implements Check {
 
-    static final String DEFAULT_MESSAGE = "Invalid title content";
-
     private Pattern pattern;
     private String message;
 
@@ -18,7 +16,7 @@ public class TitleCheck implements Check {
             throw new IllegalArgumentException("Input argument cannot be null");
         }
         pattern = title.pattern;
-        message = (title.message != null) ? title.message : DEFAULT_MESSAGE;
+        message = title.message;
     }
 
     @Override
@@ -33,6 +31,6 @@ public class TitleCheck implements Check {
 
     @Override
     public String getName() {
-        return "title-check";
+        return "title";
     }
 }

--- a/src/main/java/io/xstefank/wildfly/bot/model/Format.java
+++ b/src/main/java/io/xstefank/wildfly/bot/model/Format.java
@@ -1,18 +1,29 @@
 package io.xstefank.wildfly.bot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 
 public final class Format {
 
-    @JsonProperty("title-check")
-    public RegexDefinition titleCheck;
+    public RegexPattern title = new RegexPattern(RuntimeConstants.DEFAULT_TITLE_MESSAGE);
 
-    @JsonProperty("description")
     public Description description;
 
-    @JsonProperty("commits-message")
-    public RegexDefinition commitsMessage;
+    public RegexPattern commit = new RegexPattern(RuntimeConstants.DEFAULT_COMMIT_MESSAGE);
 
     @JsonProperty("commits-quantity")
     public CommitsQuantity commitsQuantity;
+
+    public static class RegexPattern {
+        @JsonSetter(nulls = Nulls.SKIP)
+        public String message;
+        public boolean enabled = true;
+
+        public RegexPattern() {}
+
+        public RegexPattern(String message) {
+            this.message = message;
+        }
+    }
 }

--- a/src/main/java/io/xstefank/wildfly/bot/model/RegexDefinition.java
+++ b/src/main/java/io/xstefank/wildfly/bot/model/RegexDefinition.java
@@ -6,4 +6,11 @@ public class RegexDefinition {
 
     public Pattern pattern;
     public String message;
+
+    public RegexDefinition() {}
+
+    public RegexDefinition (Pattern pattern, String message) {
+        this.pattern = pattern;
+        this.message = message;
+    }
 }

--- a/src/main/java/io/xstefank/wildfly/bot/model/RuntimeConstants.java
+++ b/src/main/java/io/xstefank/wildfly/bot/model/RuntimeConstants.java
@@ -3,4 +3,10 @@ package io.xstefank.wildfly.bot.model;
 public class RuntimeConstants {
 
     public static final String CONFIG_FILE_NAME = "wildfly-bot.yml";
+
+    public static final String DEFAULT_COMMIT_MESSAGE = "One of the commit messages has wrong format";
+
+    public static final String DEFAULT_TITLE_MESSAGE = "Wrong content of the title";
+
+    public static final String DEFAULT_PROJECT_KEY = "WFLY";
 }

--- a/src/main/java/io/xstefank/wildfly/bot/model/WildFlyConfigFile.java
+++ b/src/main/java/io/xstefank/wildfly/bot/model/WildFlyConfigFile.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import java.util.regex.Pattern;
 
 public class WildFlyConfigFile {
 
@@ -14,9 +15,19 @@ public class WildFlyConfigFile {
 
     public static final class WildFlyConfig {
 
+        private Pattern projectPattern = Pattern.compile(String.format("\\[%s-\\d+]\\s+.*|%s-\\d+\\s+.*", RuntimeConstants.DEFAULT_PROJECT_KEY, RuntimeConstants.DEFAULT_PROJECT_KEY));
+
         public List<WildFlyRule> rules;
 
-        public Format format;
+        public Format format = new Format();
+
+        public void setProjectKey(String name) {
+            projectPattern = Pattern.compile(String.format("\\[%s-\\d+]\\s+.*|%s-\\d+\\s+.*", name, name));
+        }
+
+        public Pattern getProjectPattern() {
+            return projectPattern;
+        }
 
         public List<String> emails;
     }

--- a/src/test/java/io/xstefank/wildfly/bot/PRCommitsQuantityCheckTest.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PRCommitsQuantityCheckTest.java
@@ -32,6 +32,10 @@ public class PRCommitsQuantityCheckTest {
                     commits-quantity:
                       quantity: "1-2"
                       message: "Too many commits in PR!"
+                    title:
+                      enabled: false
+                    commit:
+                      enabled: false
             """;
     }
 

--- a/src/test/java/io/xstefank/wildfly/bot/PRConfigFileChangeTest.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PRConfigFileChangeTest.java
@@ -41,9 +41,6 @@ public class PRConfigFileChangeTest {
                             - body: "test"
                                notify: [The-non-existing-user]
                           format:
-                            title-check:
-                              pattern: "\\\\[TITLE-\\\\d+\\\\]\\\\s+.*|TITLE-\\\\d+\\\\s+.*"
-                              message: "Wrong content of the title!"
                             description:
                               regexes:
                                 - pattern: "\\\\s+https://"
@@ -90,7 +87,7 @@ public class PRConfigFileChangeTest {
                           format:
                             title-check:
                               pattern: "\\\\[TITLE-\\\\d+\\\\]\\\\s+.*|TITLE-\\\\d+\\\\s+.*"
-                              message: "Wrong content of the title!"
+                              message: "Wrong content of the title"
                             description:
                               regexes:
                                 - pattern: "\\\\s+https://"

--- a/src/test/java/io/xstefank/wildfly/bot/PRDescriptionCheckTest.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PRDescriptionCheckTest.java
@@ -35,6 +35,10 @@ public class PRDescriptionCheckTest {
                         - pattern: "https://issues.redhat.com/browse/WFLY-\\\\d+"
                           message: "The PR description must contain a link to the JIRA issue"
                         - pattern: "JIRA:\\\\s+https://issues.redhat.com/browse/WFLY-\\\\d+"
+                    title:
+                      enabled: false
+                    commit:
+                      enabled: false
                 """;
     }
 

--- a/src/test/java/io/xstefank/wildfly/bot/PREditTest.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PREditTest.java
@@ -24,9 +24,6 @@ public class PREditTest {
         wildflyConfigFile = """
             wildfly:
               format:
-                title-check:
-                  pattern: "\\\\[WFLY-\\\\d+\\\\]\\\\s+.*|WFLY-\\\\d+\\\\s+.*"
-                  message: "Wrong content of the title!"
                 description:
                   regexes:
                     - pattern: "JIRA:\\\\s+https://issues.redhat.com/browse/WFLY-\\\\d+|https://issues.redhat.com/browse/WFLY-\\\\d+"
@@ -34,6 +31,8 @@ public class PREditTest {
                 commits-quantity:
                   quantity: "1-2"
                   message: "Too many commits in PR!"
+                commit:
+                  enabled: false
             """;
     }
 
@@ -74,12 +73,12 @@ public class PREditTest {
             .then().github(mocks -> {
                 GHRepository repo = mocks.repository("xstefank/wildfly");
                 Mockito.verify(repo).createCommitStatus("860035425072e50c290561191e90edc90254f900",
-                    GHCommitState.ERROR, "", "Failed checks: title-check, description, commits-quantity", "Format");
+                    GHCommitState.ERROR, "", "Failed checks: description, title, commits-quantity", "Format");
                 Mockito.verify(mocks.pullRequest(1352150111)).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
                     .formatted("""
-                        - Wrong content of the title!
-
                         - The PR description must contain a link to the JIRA issue
+
+                        - Wrong content of the title
 
                         - Too many commits in PR!"""));
             });

--- a/src/test/java/io/xstefank/wildfly/bot/PRFormatOverrideMessage.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PRFormatOverrideMessage.java
@@ -1,0 +1,98 @@
+package io.xstefank.wildfly.bot;
+
+import io.quarkiverse.githubapp.testing.GitHubAppMockito;
+import io.quarkiverse.githubapp.testing.GitHubAppTest;
+import io.quarkiverse.githubapp.testing.GitHubAppTesting;
+import io.quarkus.test.junit.QuarkusTest;
+import io.xstefank.wildfly.bot.model.RuntimeConstants;
+import io.xstefank.wildfly.bot.utils.GitHubJson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.github.GHEvent;
+import org.kohsuke.github.GHPullRequestCommitDetail;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.PagedSearchIterable;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static io.xstefank.wildfly.bot.helper.MockedGHPullRequestProcessor.processEmptyPullRequestMock;
+
+@QuarkusTest
+@GitHubAppTest
+public class PRFormatOverrideMessage {
+
+    private String wildflyConfigFile;
+
+    @BeforeEach
+    void setUp() {
+        wildflyConfigFile = """
+                wildfly:
+                  format:
+                    title:
+                      message: "Custom title message"
+                    commit:
+                      message: "Custom commit message"
+                """;
+    }
+
+    @Test
+    public void testOverridingTitleMessage() throws IOException {
+        String commitMessage = "WFLY-00000 commit";
+        GitHubAppTesting.given()
+                .github(mocks -> {
+                    mocks.configFile(RuntimeConstants.CONFIG_FILE_NAME).fromString(wildflyConfigFile);
+
+                    GHPullRequestCommitDetail mockCommitDetail = Mockito.mock(GHPullRequestCommitDetail.class);
+                    PagedSearchIterable<GHPullRequestCommitDetail> commitDetails = GitHubAppMockito.mockPagedIterable(mockCommitDetail);
+                    Mockito.when(mocks.pullRequest(1352150111).listCommits()).thenReturn(commitDetails);
+
+                    GHPullRequestCommitDetail.Commit mockCommit = Mockito.mock(GHPullRequestCommitDetail.Commit.class);
+                    Mockito.when(mockCommitDetail.getCommit()).thenReturn(mockCommit);
+                    Mockito.when(mockCommit.getMessage()).thenReturn(commitMessage);
+
+                    processEmptyPullRequestMock(mocks.pullRequest(1352150111));
+                })
+                .when().payloadFromClasspath("/pr-fail-checks.json")
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository("xstefank/wildfly");
+                    Mockito.verify(repo).createCommitStatus("860035425072e50c290561191e90edc90254f900",
+                            GHCommitState.ERROR, "", "Failed checks: title", "Format");
+                    Mockito.verify(mocks.pullRequest(1352150111)).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
+                            .formatted("- Custom title message"));
+                });
+    }
+
+    @Test
+    public void testOverridingCommitMessage() throws IOException {
+        String commitMessage = "commit message";
+        GitHubJson gitHubJson = GitHubJson.builder("pr-success-checks.json").build();
+        GitHubAppTesting.given()
+                .github(mocks -> {
+                    mocks.configFile(RuntimeConstants.CONFIG_FILE_NAME).fromString(wildflyConfigFile);
+
+                    GHPullRequestCommitDetail mockCommitDetail = Mockito.mock(GHPullRequestCommitDetail.class);
+                    Mockito.when(mockCommitDetail.getSha()).thenReturn(gitHubJson.commitSHA());
+                    PagedSearchIterable<GHPullRequestCommitDetail> commitDetails = GitHubAppMockito.mockPagedIterable(mockCommitDetail);
+                    Mockito.when(mocks.pullRequest(1352150111).listCommits()).thenReturn(commitDetails);
+
+                    GHPullRequestCommitDetail.Commit mockCommit = Mockito.mock(GHPullRequestCommitDetail.Commit.class);
+                    Mockito.when(mockCommitDetail.getCommit()).thenReturn(mockCommit);
+                    Mockito.when(mockCommit.getMessage()).thenReturn(commitMessage);
+
+                    processEmptyPullRequestMock(mocks.pullRequest(1352150111));
+                })
+                .when().payloadFromClasspath("/pr-success-checks.json")
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository("xstefank/wildfly");
+                    Mockito.verify(repo).createCommitStatus("40dbbdde147294cd8b29df16d79fe874247d8053",
+                            GHCommitState.ERROR, "", "Failed checks: commit", "Format");
+
+                    Mockito.verify(mocks.pullRequest(1352150111)).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
+                            .formatted(String.format("- For commit: \"%s\" (%s) - Custom commit message", commitMessage, gitHubJson.commitSHA())));
+                });
+    }
+}

--- a/src/test/java/io/xstefank/wildfly/bot/PRFormatOverrideProjectKey.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PRFormatOverrideProjectKey.java
@@ -1,0 +1,79 @@
+package io.xstefank.wildfly.bot;
+
+import io.quarkiverse.githubapp.testing.GitHubAppTest;
+import io.quarkus.test.junit.QuarkusTest;
+import io.xstefank.wildfly.bot.helper.MockedGHPullRequestProcessor;
+import io.xstefank.wildfly.bot.utils.Action;
+import io.xstefank.wildfly.bot.utils.GitHubJson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.github.GHEvent;
+import org.kohsuke.github.GHRepository;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
+
+@QuarkusTest
+@GitHubAppTest
+public class PRFormatOverrideProjectKey {
+
+    private String wildflyConfigFile;
+
+    @BeforeEach
+    void setUp() {
+        wildflyConfigFile = """
+                wildfly:
+                  projectKey: WFCORE
+                  format:
+                    commit:
+                      enabled: false
+                """;
+    }
+
+    @Test
+    public void testOverridingProjectKeyCorrectTitle() throws IOException {
+        GitHubJson githubJson = GitHubJson.builder("pr-template.json")
+                .action(Action.EDITED)
+                .title("WFCORE-00000 title")
+                .build();
+
+        given()
+                .github(mocks -> {
+                    mocks.configFileFromString("wildfly-bot.yml", wildflyConfigFile);
+                    MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
+                })
+                .when().payloadFromString(githubJson.jsonString())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository("xstefank/wildfly");
+                    Mockito.verify(repo).createCommitStatus("5db0f8e923d84fe05a60658ed5bb95f7aa23b66f",
+                            GHCommitState.SUCCESS, "", "Valid", "Format");
+                });
+    }
+
+    @Test
+    public void testOverridingProjectKeyIncorrectTitle() throws IOException {
+        GitHubJson githubJson = GitHubJson.builder("pr-template.json")
+                .action(Action.EDITED)
+                .title("WFLY-00000 title")
+                .build();
+
+        given()
+                .github(mocks -> {
+                    mocks.configFileFromString("wildfly-bot.yml", wildflyConfigFile);
+                    MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
+                })
+                .when().payloadFromString(githubJson.jsonString())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository("xstefank/wildfly");
+                    Mockito.verify(repo).createCommitStatus("5db0f8e923d84fe05a60658ed5bb95f7aa23b66f",
+                            GHCommitState.ERROR, "", "Failed checks: title", "Format");
+                    Mockito.verify(mocks.pullRequest(1371642823)).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
+                            .formatted("- Wrong content of the title"));
+                });
+    }
+}

--- a/src/test/java/io/xstefank/wildfly/bot/PROpenedTest.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PROpenedTest.java
@@ -33,6 +33,9 @@ public class PROpenedTest {
                             - id: "Best"
                               title: "Best"
                               notify: [3251142365,4533458845]
+                          format:
+                            commit:
+                              enabled: false
                         """);
 
                 MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
@@ -45,9 +48,9 @@ public class PROpenedTest {
                 GHRepository repo = mocks.repository("xstefank/wildfly");
                 // TODO The expected state should be SUCCESS. Fix this test as part of the issue #59.
                 Mockito.verify(repo).createCommitStatus("5db0f8e923d84fe05a60658ed5bb95f7aa23b66f",
-                    GHCommitState.ERROR, "", "Failed checks: title-check", "Format");
+                    GHCommitState.ERROR, "", "Failed checks: title", "Format");
                 Mockito.verify(mockedPR).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
-                    .formatted("- Wrong content of the title!"));
+                    .formatted("- Wrong content of the title"));
                 Mockito.verify(mockedPR).listFiles();
                 Mockito.verify(mockedPR).listComments();
                 Mockito.verifyNoMoreInteractions(mocks.ghObjects());
@@ -67,6 +70,9 @@ public class PROpenedTest {
                             - id: "Best"
                               title: "Commit"
                               notify: [7125767235,4533458845]
+                          format:
+                            commit:
+                              enabled: false
                         """);
 
                 MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
@@ -83,7 +89,9 @@ public class PROpenedTest {
                 // There is a problem with test isolation (see issue #59), but the important check is if there are
                 // only 3 mentioned users.
                 Mockito.verify(repo).createCommitStatus("5db0f8e923d84fe05a60658ed5bb95f7aa23b66f",
-                    GHCommitState.SUCCESS, "", "Valid", "Format");
+                        GHCommitState.ERROR, "", "Failed checks: title", "Format");
+                Mockito.verify(mockedPR).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
+                        .formatted("- Wrong content of the title"));
                 Mockito.verify(mockedPR).listFiles();
                 Mockito.verify(mockedPR).listComments();
                 Mockito.verifyNoMoreInteractions(mocks.ghObjects());
@@ -102,6 +110,9 @@ public class PROpenedTest {
                               body: "there"
                               titleBody: "test"
                               notify: [7125767235]
+                          format:
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
             })
@@ -113,7 +124,9 @@ public class PROpenedTest {
                     .comment("/cc @7125767235");
                 GHRepository repo = mocks.repository("xstefank/wildfly");
                 Mockito.verify(repo).createCommitStatus("5db0f8e923d84fe05a60658ed5bb95f7aa23b66f",
-                    GHCommitState.SUCCESS, "", "Valid", "Format");
+                        GHCommitState.ERROR, "", "Failed checks: title", "Format");
+                Mockito.verify(mockedPR).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
+                        .formatted("- Wrong content of the title"));
                 Mockito.verify(mockedPR).listFiles();
                 Mockito.verify(mockedPR).listComments();
                 Mockito.verifyNoMoreInteractions(mocks.ghObjects());
@@ -132,6 +145,9 @@ public class PROpenedTest {
                               body: "there"
                               titleBody: "foobar"
                               notify: [7125767235]
+                          format:
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
             })
@@ -143,7 +159,9 @@ public class PROpenedTest {
                     .comment("/cc @7125767235");
                 GHRepository repo = mocks.repository("xstefank/wildfly");
                 Mockito.verify(repo).createCommitStatus("5db0f8e923d84fe05a60658ed5bb95f7aa23b66f",
-                    GHCommitState.SUCCESS, "", "Valid", "Format");
+                        GHCommitState.ERROR, "", "Failed checks: title", "Format");
+                Mockito.verify(mockedPR).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
+                        .formatted("- Wrong content of the title"));
                 Mockito.verify(mockedPR).listFiles();
                 Mockito.verify(mockedPR).listComments();
                 Mockito.verifyNoMoreInteractions(mocks.ghObjects());
@@ -160,6 +178,9 @@ public class PROpenedTest {
                             - id: "Hello Test"
                               titleBody: "FoObAr"
                               notify: [7125767235]
+                          format:
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
             })
@@ -181,6 +202,9 @@ public class PROpenedTest {
                             - id: "Hello Test"
                               title: "TeSt"
                               notify: [7125767235]
+                          format:
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
             })
@@ -202,6 +226,9 @@ public class PROpenedTest {
                             - id: "Hello Test"
                               body: "FoObAr"
                               notify: [7125767235]
+                          format:
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
             })
@@ -225,6 +252,9 @@ public class PROpenedTest {
                               body: "there"
                               titleBody: "General Kenobi"
                               notify: [7125767235]
+                          format:
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
             })
@@ -234,8 +264,10 @@ public class PROpenedTest {
                 GHPullRequest mockedPR = mocks.pullRequest(1371642823);
                 Mockito.verify(mockedPR, Mockito.never()).comment("/cc @7125767235");
                 GHRepository repo = mocks.repository("xstefank/wildfly");
-                Mockito.verify(repo).createCommitStatus("5db0f8e923d84fe05a60658ed5bb95f7aa23b66f",
-                    GHCommitState.SUCCESS, "", "Valid", "Format");
+                    Mockito.verify(repo).createCommitStatus("5db0f8e923d84fe05a60658ed5bb95f7aa23b66f",
+                            GHCommitState.ERROR, "", "Failed checks: title", "Format");
+                    Mockito.verify(mockedPR).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
+                            .formatted("- Wrong content of the title"));
                 Mockito.verify(mockedPR).listFiles();
                 Mockito.verify(mockedPR).listComments();
                 Mockito.verifyNoMoreInteractions(mocks.ghObjects());
@@ -253,6 +285,9 @@ public class PROpenedTest {
                               directories:
                                - appclient
                               notify: [7125767235]
+                          format:
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processPullRequestMock(mocks.pullRequest(1371642823),
                     mockFileDetails(), MockedGHPullRequestProcessor.mockEmptyComments());
@@ -265,7 +300,7 @@ public class PROpenedTest {
                 Mockito.verify(mockedPR).comment("/cc @7125767235");
                 Mockito.verify(mockedPR, Mockito.times(1)).listComments();
                 Mockito.verify(mockedPR).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
-                    .formatted("- Wrong content of the title!"));
+                    .formatted("- Wrong content of the title"));
                 Mockito.verifyNoMoreInteractions(mockedPR);
             });
     }
@@ -281,6 +316,9 @@ public class PROpenedTest {
                               directories:
                                - microprofile/health-smallrye
                               notify: [7125767235]
+                          format:
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processPullRequestMock(mocks.pullRequest(1371642823),
                     mockFileDetails(), MockedGHPullRequestProcessor.mockEmptyComments());
@@ -292,7 +330,7 @@ public class PROpenedTest {
                 Mockito.verify(mockedPR, Mockito.times(2)).listFiles();
                 Mockito.verify(mockedPR, Mockito.times(1)).listComments();
                 Mockito.verify(mockedPR).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
-                    .formatted("- Wrong content of the title!"));
+                    .formatted("- Wrong content of the title"));
                 Mockito.verify(mockedPR).comment("/cc @7125767235");
                 Mockito.verifyNoMoreInteractions(mockedPR);
             });
@@ -309,6 +347,9 @@ public class PROpenedTest {
                               directories:
                                - testsuite/integration
                               notify: [7125767235]
+                          format:
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processPullRequestMock(mocks.pullRequest(1371642823),
                     mockFileDetails(), MockedGHPullRequestProcessor.mockEmptyComments());
@@ -319,6 +360,8 @@ public class PROpenedTest {
                 GHPullRequest mockedPR = mocks.pullRequest(1371642823);
                 Mockito.verify(mockedPR, Mockito.times(2)).listFiles();
                 Mockito.verify(mockedPR, Mockito.times(1)).listComments();
+                Mockito.verify(mockedPR).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
+                        .formatted("- Wrong content of the title"));
                 Mockito.verify(mockedPR).comment("/cc @7125767235");
                 Mockito.verifyNoMoreInteractions(mockedPR);
             });
@@ -335,6 +378,9 @@ public class PROpenedTest {
                               directories:
                                - transactions
                               notify: [7125767235]
+                          format:
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processPullRequestMock(mocks.pullRequest(1371642823),
                     mockFileDetails(), MockedGHPullRequestProcessor.mockEmptyComments());
@@ -346,7 +392,7 @@ public class PROpenedTest {
                 Mockito.verify(mockedPR, Mockito.times(2)).listFiles();
                 Mockito.verify(mockedPR, Mockito.times(1)).listComments();
                 Mockito.verify(mockedPR).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
-                    .formatted("- Wrong content of the title!"));
+                    .formatted("- Wrong content of the title"));
                 Mockito.verifyNoMoreInteractions(mockedPR);
             });
     }
@@ -362,9 +408,8 @@ public class PROpenedTest {
                             - body: "there"
                               notify: [7125767235]
                           format:
-                            title-check:
-                              pattern: "\\\\[WFLY-\\\\d+\\\\]\\\\s+.*|WFLY-\\\\d+\\\\s+.*"
-                              message: "Wrong content of the title!"
+                            commit:
+                              enabled: false
                         """);
                 MockedGHPullRequestProcessor.processEmptyPullRequestMock(mocks.pullRequest(1371642823));
             })
@@ -373,9 +418,9 @@ public class PROpenedTest {
             .then().github(mocks -> {
                 GHRepository repo = mocks.repository("xstefank/wildfly");
                 Mockito.verify(repo).createCommitStatus("5db0f8e923d84fe05a60658ed5bb95f7aa23b66f",
-                    GHCommitState.ERROR, "", "Failed checks: title-check", "Format");
+                    GHCommitState.ERROR, "", "Failed checks: title", "Format");
                 Mockito.verify(mocks.pullRequest(1371642823)).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
-                    .formatted("- Wrong content of the title!"));
+                    .formatted("- Wrong content of the title"));
             });
     }
 

--- a/src/test/java/io/xstefank/wildfly/bot/PRTitleCheckTest.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PRTitleCheckTest.java
@@ -29,9 +29,8 @@ public class PRTitleCheckTest {
         wildflyConfigFile = """
             wildfly:
               format:
-                title-check:
-                  pattern: "\\\\[WFLY-\\\\d+\\\\]\\\\s+.*|WFLY-\\\\d+\\\\s+.*"
-                  message: "Wrong content of the title!"
+                commit:
+                  enabled: false
             """;
     }
 
@@ -56,9 +55,9 @@ public class PRTitleCheckTest {
             .then().github(mocks -> {
                 GHRepository repo = mocks.repository("xstefank/wildfly");
                 Mockito.verify(repo).createCommitStatus("860035425072e50c290561191e90edc90254f900",
-                    GHCommitState.ERROR, "", "Failed checks: title-check", "Format");
+                    GHCommitState.ERROR, "", "Failed checks: title", "Format");
                 Mockito.verify(mocks.pullRequest(1352150111)).comment(PullRequestFormatProcessor.FAILED_FORMAT_COMMENT
-                    .formatted("- Wrong content of the title!"));
+                    .formatted("- Wrong content of the title"));
             });
     }
 

--- a/src/test/java/io/xstefank/wildfly/bot/utils/GitHubJson.java
+++ b/src/test/java/io/xstefank/wildfly/bot/utils/GitHubJson.java
@@ -80,7 +80,6 @@ public class GitHubJson {
             ((ObjectNode) this.jsonFile.get(PULL_REQUEST)).put(COMMITS, quantity);
             return this;
         }
-
         public GitHubJson build() {
             return new GitHubJson(this);
         }

--- a/wildfly-bot-config-example.yml
+++ b/wildfly-bot-config-example.yml
@@ -1,38 +1,40 @@
 wildfly:
-  rules:                  # list of objects with no mandatory fields. The rule is fired if at least one check is satisfied. The object is as follows
-    - id: id-1            # each rule should have unique id
-      title: "resteasy"   # string looked-up in the title of the Pull Request
-      notify:             # list of users to notify with a `/cc` comment
+  projectKey: "WFCORE"    # Abbreviation for project, used for title, commit check. By default, this setting is set to "WFLY"
+
+  rules:                  # List of objects with no mandatory fields. The rule is fired if at least one check is satisfied. The object is as follows
+    - id: id-1            # Each rule should have unique id
+      title: "resteasy"   # String looked-up in the title of the Pull Request
+      notify:             # List of users to notify with a `/cc` comment
         - random-person
         - random-person-2
     - id: id-2
-      body: "hibernate"   # string looked-up in the body of the Pull Request
+      body: "hibernate"   # String looked-up in the body of the Pull Request
       notify: [ random-person ]
 
     - id: id-3
-      titleBody: "health"                                       # string looked-up either in the title, the body or both
-      directories: [ src/main/, src/test/org/acme/resources/* ] # list of directories, supporting glob matching if wildcard '*' is used. Matches at least one file found changed by the Pull Request
+      titleBody: "health"                                       # String looked-up either in the title, the body or both
+      directories: [ src/main/, src/test/org/acme/resources/* ] # List of directories. Matches at least one file found changed by the Pull Request
       notify: [ another-random-person ]
 
-  format:                 # validation check for a correct format of the Pull Request
-    title-check:
-      pattern: "\\[WFLY-\\d+\\]\\s+.*|WFLY-\\d+\\s+.*"    # regex pattern must be matched by the title
-      message: "Wrong content of the title!"              # message to display if check does not succeed
+  format:                 # Validation check for a correct format of the Pull Request
+    title:                                      # Enabled by default. You have to disable explicitly.
+      enabled: false                            # If check enabled. By default, this setting is set true
+      message: "Wrong content of the title"    # Override default message. Message is display if check does not succeed
 
     description:
-      regexes:            # list of objects, where the object is as follows:
-        - pattern: "JIRA:\\s+https://issues.redhat.com/browse/WFLY-\\d+|https://issues.redhat.com/browse/WFLY-\\d+"   # regex pattern must be matched by the title
-          message: "The PR description must contain a link to the JIRA issue"                                         # message to display if check does not succeed
-      message: "The PR description is not correct"                                                                    # default message to display if a object is missing message field
+      regexes:            # List of objects, where the object is as follows:
+        - pattern: "JIRA:\\s+https://issues.redhat.com/browse/WFLY-\\d+|https://issues.redhat.com/browse/WFLY-\\d+"   # Regex pattern must be matched by the title
+          message: "The PR description must contain a link to the JIRA issue"                                         # Message to display if check does not succeed
+      message: "The PR description is not correct"                                                                    # Default message to display if a object is missing message field
 
     commits-quantity:
-      quantity: "1-3"                       # single value or a range. Values between 0-100. No spaces allowed.
-      message: "Too many commits in PR!"    # message to display if check does not succeed
+      quantity: "1-3"                       # Single value or a range. Values between 0-100. No spaces allowed.
+      message: "Too many commits in PR!"    # Message to display if check does not succeed
 
-    commits-message:
-      pattern: "\\[WFLY-\\d+\\]\\s+.*|WFLY-\\d+\\s+.*"    # regex pattern must be matched by the commit message
-      message: "Wrong content of the title!"              # message to display if check does not succeed
+    commit:                                     # Enabled by default. You have to disable explicitly.
+      enabled: true                             # If check enabled. By default, this setting is set true
+      message: "Wrong commit message!"          # Override default message. Message is display if check does not succeed
 
-  emails:     # list of email addresses, which will receive updates from this app
+  emails:     # List of email addresses, which will receive updates from this app
     - random-person@bar.baz
     - another-random-person@gmail.com


### PR DESCRIPTION
* add entry for `projectKey` and generate default regex pattern.
* `title` and `commit-message` enabled by default. Allow overriding message.