### PR TITLE
Remove possible message length problems created by Pull Request

### DIFF
--- a/src/main/java/io/xstefank/wildfly/bot/ConfigFileChangeProcessor.java
+++ b/src/main/java/io/xstefank/wildfly/bot/ConfigFileChangeProcessor.java
@@ -55,9 +55,8 @@ public class ConfigFileChangeProcessor {
                             githubCommitProcessor.commitStatusSuccess(pullRequest, CHECK_NAME, "Valid");
                             Log.debug("Configuration File check successful");
                         } else {
-                            String message = String.join(",", problems);
-                            githubCommitProcessor.commitStatusError(pullRequest, CHECK_NAME, message);
-                            Log.warnf("Configuration File check unsuccessful. %s", message);
+                            githubCommitProcessor.commitStatusError(pullRequest, CHECK_NAME, "Rule is missing an id or multiple rules have the same id.");
+                            Log.warnf("Configuration File check unsuccessful. %s", String.join(",", problems));
                         }
                     } else {
                         String message = "Configuration File check unsuccessful. Unable to correctly map loaded file to YAML.";

--- a/src/main/java/io/xstefank/wildfly/bot/format/CommitMessagesCheck.java
+++ b/src/main/java/io/xstefank/wildfly/bot/format/CommitMessagesCheck.java
@@ -28,15 +28,15 @@ public class CommitMessagesCheck implements Check {
         PagedIterable<GHPullRequestCommitDetail> commits = pullRequest.listCommits();
         for (GHPullRequestCommitDetail commit : commits) {
 
-            String commitMessage =  commit.getCommit().getMessage();
-            if (commitMessage.isEmpty()) {
+            String commitSha =  commit.getSha();
+            if (commitSha.isEmpty()) {
                 return commit.getSha() + ": Commit message is Empty";
             }
 
-            Matcher matcher = pattern.matcher(commitMessage);
+            Matcher matcher = pattern.matcher(commitSha);
 
             if (!matcher.matches()) {
-                return String.format("For commit: \"%s\" %s" , commitMessage, this.message);
+                return String.format("For commit: \"%s\" %s" , commitSha, this.message);
             }
         }
         return null;


### PR DESCRIPTION
Based on #93 . Only solves for Pull Request invocation. However I will update this further to check `message` from yaml file. No time for that and another PR will change the structure of the config file anyway.