### PR TITLE
Add default value for wildfly, format and rework RegexPattern

### DIFF
--- a/src/main/java/io/xstefank/wildfly/bot/TriagePullRequestProcessor.java
+++ b/src/main/java/io/xstefank/wildfly/bot/TriagePullRequestProcessor.java
@@ -35,15 +35,13 @@ public class TriagePullRequestProcessor {
         GHPullRequest pullRequest = pullRequestPayload.getPullRequest();
         List<String> mentions = new ArrayList<>();
 
-        if (wildflyBotConfigFile.wildfly.rules != null) {
-            for (WildFlyRule rule : wildflyBotConfigFile.wildfly.rules) {
-                if (Matcher.matches(pullRequest, rule)) {
-                    LOG.infof("Pull Request %s was matched with a rule with the id: %s.", pullRequest.getTitle(),
+        for (WildFlyRule rule : wildflyBotConfigFile.wildfly.rules) {
+            if (Matcher.matches(pullRequest, rule)) {
+                LOG.infof("Pull Request %s was matched with a rule with the id: %s.", pullRequest.getTitle(),
                         rule.id != null ? rule.id : "N/A");
-                    for (String nick : rule.notify) {
-                        if (!nick.equals(pullRequest.getUser().getLogin()) && !mentions.contains(nick)) {
-                            mentions.add(nick);
-                        }
+                for (String nick : rule.notify) {
+                    if (!nick.equals(pullRequest.getUser().getLogin()) && !mentions.contains(nick)) {
+                        mentions.add(nick);
                     }
                 }
             }

--- a/src/main/java/io/xstefank/wildfly/bot/format/CommitMessagesCheck.java
+++ b/src/main/java/io/xstefank/wildfly/bot/format/CommitMessagesCheck.java
@@ -8,7 +8,6 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.io.IOException;
 
-import static io.xstefank.wildfly.bot.model.RuntimeConstants.DEFAULT_COMMIT_MESSAGE;
 import static io.xstefank.wildfly.bot.model.RuntimeConstants.DEPENDABOT;
 
 public class CommitMessagesCheck implements Check {
@@ -21,7 +20,7 @@ public class CommitMessagesCheck implements Check {
             throw new IllegalArgumentException("Input argument cannot be null");
         }
         pattern = description.pattern;
-        message = description.message != null ? description.message : DEFAULT_COMMIT_MESSAGE;
+        message = description.message;
     }
 
     @Override

--- a/src/main/java/io/xstefank/wildfly/bot/format/TitleCheck.java
+++ b/src/main/java/io/xstefank/wildfly/bot/format/TitleCheck.java
@@ -6,8 +6,6 @@ import org.kohsuke.github.GHPullRequest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static io.xstefank.wildfly.bot.model.RuntimeConstants.DEFAULT_TITLE_MESSAGE;
-
 public class TitleCheck implements Check {
 
     private Pattern pattern;
@@ -18,7 +16,7 @@ public class TitleCheck implements Check {
             throw new IllegalArgumentException("Input argument cannot be null");
         }
         pattern = title.pattern;
-        message = title.message != null ? title.message : DEFAULT_TITLE_MESSAGE;
+        message = title.message;
     }
 
     @Override

--- a/src/main/java/io/xstefank/wildfly/bot/model/Format.java
+++ b/src/main/java/io/xstefank/wildfly/bot/model/Format.java
@@ -5,21 +5,33 @@ import com.fasterxml.jackson.annotation.Nulls;
 
 public final class Format {
 
-    public RegexPattern title = new RegexPattern(RuntimeConstants.DEFAULT_TITLE_MESSAGE);
+    @JsonSetter(nulls = Nulls.SKIP)
+    public TitlePattern title = new TitlePattern();
 
+    @JsonSetter(nulls = Nulls.SKIP)
     public Description description;
 
-    public RegexPattern commit = new RegexPattern(RuntimeConstants.DEFAULT_COMMIT_MESSAGE);
+    @JsonSetter(nulls = Nulls.SKIP)
+    public CommitPattern commit = new CommitPattern();
 
-    public static class RegexPattern {
-        @JsonSetter(nulls = Nulls.SKIP)
+    public abstract static class RegexPattern {
         public String message;
         public boolean enabled = true;
 
-        public RegexPattern() {}
-
         public RegexPattern(String message) {
             this.message = message;
+        }
+    }
+
+    public static class TitlePattern extends RegexPattern {
+        public TitlePattern() {
+            super(RuntimeConstants.DEFAULT_TITLE_MESSAGE);
+        }
+    }
+
+    public static class CommitPattern extends RegexPattern {
+        public CommitPattern() {
+            super(RuntimeConstants.DEFAULT_COMMIT_MESSAGE);
         }
     }
 }

--- a/src/main/java/io/xstefank/wildfly/bot/model/WildFlyConfigFile.java
+++ b/src/main/java/io/xstefank/wildfly/bot/model/WildFlyConfigFile.java
@@ -1,5 +1,7 @@
 package io.xstefank.wildfly.bot.model;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.ArrayList;
@@ -16,7 +18,8 @@ public class WildFlyConfigFile {
     public static final String PROJECT_PATTERN_REGEX = "\\[%s-\\d+]\\s+.*|%s-\\d+\\s+.*";
     public static final String PROJECT_PATTERN_REGEX_PREFIXED = ".*\\[%s-\\d+]\\s+.*|.*%s-\\d+\\s+.*";
 
-    public WildFlyConfig wildfly;
+    @JsonSetter(nulls = Nulls.SKIP)
+    public WildFlyConfig wildfly = new WildFlyConfig();
 
     public static final class WildFlyConfig {
 
@@ -26,8 +29,10 @@ public class WildFlyConfigFile {
         private Pattern projectPatternPrefixed = Pattern.compile(String.format(PROJECT_PATTERN_REGEX_PREFIXED,
             DEFAULT_PROJECT_KEY, DEFAULT_PROJECT_KEY), Pattern.DOTALL);
 
-        public List<WildFlyRule> rules;
+        @JsonSetter(nulls = Nulls.SKIP)
+        public List<WildFlyRule> rules = new ArrayList<>();
 
+        @JsonSetter(nulls = Nulls.SKIP)
         public Format format = new Format();
 
         public String projectKey = DEFAULT_PROJECT_KEY;

--- a/src/test/java/io/xstefank/wildfly/bot/PRDescriptionCheckTest.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PRDescriptionCheckTest.java
@@ -6,7 +6,6 @@ import io.xstefank.wildfly.bot.format.DescriptionCheck;
 import io.xstefank.wildfly.bot.model.Description;
 import io.xstefank.wildfly.bot.utils.GitHubJson;
 import io.xstefank.wildfly.bot.utils.Util;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.kohsuke.github.GHEvent;
 import org.kohsuke.github.GHRepository;
@@ -15,8 +14,9 @@ import java.io.IOException;
 
 import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
 import static io.xstefank.wildfly.bot.utils.TestConstants.INVALID_DESCRIPTION;
-import static io.xstefank.wildfly.bot.utils.TestConstants.VALID_PR_TEMPLATE_JSON;
 import static io.xstefank.wildfly.bot.utils.TestConstants.TEST_REPO;
+import static io.xstefank.wildfly.bot.utils.TestConstants.VALID_PR_TEMPLATE_JSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -35,7 +35,7 @@ public class PRDescriptionCheckTest {
 
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
             () -> new DescriptionCheck(description));
-        Assertions.assertEquals("Input argument cannot be null", thrown.getMessage());
+        assertEquals("Input argument cannot be null", thrown.getMessage());
     }
 
     @Test
@@ -106,6 +106,24 @@ public class PRDescriptionCheckTest {
                 GHRepository repo = mocks.repository(TEST_REPO);
                 Util.verifyFormatSuccess(repo, gitHubJson);
             });
+    }
+
+    @Test
+    void testDescriptionCheckSuccessDescriptionConfigNull() throws IOException {
+        wildflyConfigFile = """
+                wildfly:
+                  format:
+                    description:
+                """;
+        gitHubJson = GitHubJson.builder(VALID_PR_TEMPLATE_JSON).build();
+
+        given().github(mocks -> Util.mockRepo(mocks, wildflyConfigFile, gitHubJson, null))
+                .when().payloadFromString(gitHubJson.jsonString())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository(TEST_REPO);
+                    Util.verifyFormatSuccess(repo, gitHubJson);
+                });
     }
 
     @Test

--- a/src/test/java/io/xstefank/wildfly/bot/PRTitleCheckTest.java
+++ b/src/test/java/io/xstefank/wildfly/bot/PRTitleCheckTest.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
 import static io.xstefank.wildfly.bot.model.RuntimeConstants.DEFAULT_TITLE_MESSAGE;
 import static io.xstefank.wildfly.bot.utils.TestConstants.INVALID_TITLE;
-import static io.xstefank.wildfly.bot.utils.TestConstants.VALID_PR_TEMPLATE_JSON;
 import static io.xstefank.wildfly.bot.utils.TestConstants.TEST_REPO;
+import static io.xstefank.wildfly.bot.utils.TestConstants.VALID_PR_TEMPLATE_JSON;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -61,6 +61,129 @@ public class PRTitleCheckTest {
                 Util.verifyFailedFormatComment(mocks, gitHubJson, "- " + String.format(DEFAULT_TITLE_MESSAGE,
                     WildFlyConfigFile.PROJECT_PATTERN_REGEX_PREFIXED.formatted("WFLY", "WFLY")));
             });
+    }
+
+    @Test
+    void incorrectTitleCheckFailFormatConfigMissingTest() throws IOException {
+        gitHubJson = GitHubJson.builder(VALID_PR_TEMPLATE_JSON)
+                .title(INVALID_TITLE)
+                .build();
+        wildflyConfigFile = """
+                wildfly:
+                """;
+
+        given()
+                .github(mocks -> Util.mockRepo(mocks, wildflyConfigFile, gitHubJson, null))
+                .when().payloadFromString(gitHubJson.jsonString())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository(TEST_REPO);
+                    Util.verifyFormatFailure(repo, gitHubJson, "title");
+                    Util.verifyFailedFormatComment(mocks, gitHubJson, "- " + String.format(DEFAULT_TITLE_MESSAGE,
+                            WildFlyConfigFile.PROJECT_PATTERN_REGEX_PREFIXED.formatted("WFLY", "WFLY")));
+                });
+    }
+
+    @Test
+    void correctTitleCheckFailFormatConfigMissingTest() throws IOException {
+        gitHubJson = GitHubJson.builder(VALID_PR_TEMPLATE_JSON)
+                .build();
+        wildflyConfigFile = """
+                wildfly:
+                """;
+
+        given()
+                .github(mocks -> Util.mockRepo(mocks, wildflyConfigFile, gitHubJson, null))
+                .when().payloadFromString(gitHubJson.jsonString())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository(TEST_REPO);
+                    Util.verifyFormatSuccess(repo, gitHubJson);
+                });
+    }
+
+    @Test
+    void incorrectTitleCheckFailFormatConfigNullTest() throws IOException {
+        gitHubJson = GitHubJson.builder(VALID_PR_TEMPLATE_JSON)
+                .title(INVALID_TITLE)
+                .build();
+        wildflyConfigFile = """
+                wildfly:
+                  format:
+                """;
+
+        given()
+                .github(mocks -> Util.mockRepo(mocks, wildflyConfigFile, gitHubJson, null))
+                .when().payloadFromString(gitHubJson.jsonString())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository(TEST_REPO);
+                    Util.verifyFormatFailure(repo, gitHubJson, "title");
+                    Util.verifyFailedFormatComment(mocks, gitHubJson, "- " + String.format(DEFAULT_TITLE_MESSAGE,
+                            WildFlyConfigFile.PROJECT_PATTERN_REGEX_PREFIXED.formatted("WFLY", "WFLY")));
+                });
+    }
+
+    @Test
+    void correctTitleCheckFailFormatConfigNullTest() throws IOException {
+        gitHubJson = GitHubJson.builder(VALID_PR_TEMPLATE_JSON)
+                .build();
+        wildflyConfigFile = """
+                wildfly:
+                  format:
+                """;
+
+        given()
+                .github(mocks -> Util.mockRepo(mocks, wildflyConfigFile, gitHubJson, null))
+                .when().payloadFromString(gitHubJson.jsonString())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository(TEST_REPO);
+                    Util.verifyFormatSuccess(repo, gitHubJson);
+                });
+    }
+
+    @Test
+    void incorrectTitleCheckFailFormatTitleConfigNullTest() throws IOException {
+        gitHubJson = GitHubJson.builder(VALID_PR_TEMPLATE_JSON)
+                .title(INVALID_TITLE)
+                .build();
+        wildflyConfigFile = """
+                wildfly:
+                  format:
+                    title:
+                """;
+
+        given()
+                .github(mocks -> Util.mockRepo(mocks, wildflyConfigFile, gitHubJson, null))
+                .when().payloadFromString(gitHubJson.jsonString())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository(TEST_REPO);
+                    Util.verifyFormatFailure(repo, gitHubJson, "title");
+                    Util.verifyFailedFormatComment(mocks, gitHubJson, "- " + String.format(DEFAULT_TITLE_MESSAGE,
+                            WildFlyConfigFile.PROJECT_PATTERN_REGEX_PREFIXED.formatted("WFLY", "WFLY")));
+                });
+    }
+
+    @Test
+    void correctTitleCheckFailFormatTitleConfigNullTest() throws IOException {
+        gitHubJson = GitHubJson.builder(VALID_PR_TEMPLATE_JSON)
+                .build();
+        wildflyConfigFile = """
+                wildfly:
+                  format:
+                    title:
+                """;
+
+        given()
+                .github(mocks -> Util.mockRepo(mocks, wildflyConfigFile, gitHubJson, null))
+                .when().payloadFromString(gitHubJson.jsonString())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> {
+                    GHRepository repo = mocks.repository(TEST_REPO);
+                    Util.verifyFormatSuccess(repo, gitHubJson);
+                });
     }
 
     @Test


### PR DESCRIPTION
Resolves #114 and resolves a bug found by @petrberan , when only `RegexPattern.enabled` property is set to `true` and `RegexPattern.message` then results in `null`.