### PR TITLE
Update Quarkus to 3.34.2 and quarkus-github-app to 2.14.0

### DIFF
--- a/.github/workflows/polling-tests.yml
+++ b/.github/workflows/polling-tests.yml
@@ -26,4 +26,4 @@ jobs:
         java-version: ${{ matrix.java-version }}
 
     - name: Build with Maven
-      run: ./mvnw -B test -Dquarkus.test.profile=test,polling
+      run: ./mvnw -B test -Dquarkus.test.profile=polling,test # order is important, test profile should be last to override polling's configuration

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-github-app.version>2.5.1</quarkus-github-app.version>
+    <quarkus-github-app.version>2.14.0</quarkus-github-app.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.9.2</quarkus.platform.version>
+    <quarkus.platform.version>3.34.2</quarkus.platform.version>
     <surefire-plugin.version>3.2.3</surefire-plugin.version>
     <version.checkstyle>3.3.1</version.checkstyle>
     <version.org.wildfly.checkstyle>1.0.8.Final</version.org.wildfly.checkstyle>
@@ -63,17 +63,17 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/wildfly/bot/InstallationObserver.java
+++ b/src/main/java/org/wildfly/bot/InstallationObserver.java
@@ -1,0 +1,33 @@
+package org.wildfly.bot;
+
+import io.quarkiverse.githubapp.event.Installation;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.logging.Logger;
+import org.kohsuke.github.GHAppInstallation;
+import org.kohsuke.github.GHEventPayload;
+import org.wildfly.bot.util.GitHubBotContextProvider;
+
+@ApplicationScoped
+public class InstallationObserver {
+
+    private static final Logger LOG = Logger.getLogger(InstallationObserver.class);
+
+    @Inject
+    GitHubBotContextProvider botContextProvider;
+
+    void suspendedInstallation(@Installation.Suspend GHEventPayload.Installation installationPayload) {
+        GHAppInstallation installation = installationPayload.getInstallation();
+        LOG.infof(
+                "%s has been suspended for following installation id: %d and will not be able to listen for any incoming Events.",
+                botContextProvider.getBotName(), installation.getAppId());
+    }
+
+    void unsuspendedInstallation(@Installation.Unsuspend GHEventPayload.Installation installationPayload) {
+        GHAppInstallation installation = installationPayload.getInstallation();
+        LOG.infof(
+                "%s has been unsuspended for following installation id: %d and has started to listen for new incoming Events.",
+                botContextProvider.getBotName(), installation.getAppId());
+    }
+}

--- a/src/main/java/org/wildfly/bot/LifecycleProcessor.java
+++ b/src/main/java/org/wildfly/bot/LifecycleProcessor.java
@@ -3,7 +3,7 @@ package org.wildfly.bot;
 import io.quarkiverse.githubapp.ConfigFile;
 import io.quarkiverse.githubapp.GitHubClientProvider;
 import io.quarkiverse.githubapp.GitHubConfigFileProvider;
-import io.quarkiverse.githubapp.event.Installation;
+
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
 import org.wildfly.bot.config.WildFlyBotConfig;
@@ -13,11 +13,10 @@ import org.wildfly.bot.util.GitHubBotContextProvider;
 import org.wildfly.bot.util.GithubProcessor;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.inject.Any;
+
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 import org.kohsuke.github.GHAppInstallation;
-import org.kohsuke.github.GHEventPayload;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.HttpException;
@@ -56,7 +55,6 @@ public class LifecycleProcessor {
     GitHubBotContextProvider botContextProvider;
 
     @Inject
-    @Any
     ConfigFileChangeProcessor configFileChangeProcessor;
 
     @Inject
@@ -122,20 +120,6 @@ public class LifecycleProcessor {
             LOG.errorf(e, "Unable to correctly start %s for following installation id [%d]", botContextProvider.getBotName(),
                     installationId);
         }
-    }
-
-    void suspendedInstallation(@Installation.Suspend GHEventPayload.Installation installationPayload) {
-        GHAppInstallation installation = installationPayload.getInstallation();
-        LOG.infof(
-                "%s has been suspended for following installation id: %d and will not be able to listen for any incoming Events.",
-                botContextProvider.getBotName(), installation.getAppId());
-    }
-
-    void unsuspendedInstallation(@Installation.Unsuspend GHEventPayload.Installation installationPayload) {
-        GHAppInstallation installation = installationPayload.getInstallation();
-        LOG.infof(
-                "%s has been unsuspended for following installation id: %d and has started to listen for new incoming Events.",
-                botContextProvider.getBotName(), installation.getAppId());
     }
 
     private String prettyString(List<String> problems) {

--- a/src/main/java/org/wildfly/bot/polling/EventPollingProcessor.java
+++ b/src/main/java/org/wildfly/bot/polling/EventPollingProcessor.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkiverse.githubapp.GitHubEvent;
+import io.quarkiverse.githubapp.runtime.SimpleGitHubEvent;
 import io.quarkiverse.githubapp.runtime.github.GitHubService;
 import io.quarkus.scheduler.Scheduled;
 import io.smallrye.mutiny.tuples.Tuple2;
@@ -67,7 +68,7 @@ public class EventPollingProcessor implements GitHubEventEmitter<Throwable> {
                             LOG.infof("Unable to determine the type of event with payload\n%s", payload);
                             continue;
                         }
-                        GitHubEvent gitHubEvent = new GitHubEvent(app.getId(),
+                        GitHubEvent gitHubEvent = new SimpleGitHubEvent(app.getId(),
                                 null, null, eventInfo.getRepository().getFullName(),
                                 type,
                                 eventTuple.getItem2(),

--- a/src/main/java/org/wildfly/bot/polling/GitHubEventPreprocessor.java
+++ b/src/main/java/org/wildfly/bot/polling/GitHubEventPreprocessor.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.quarkiverse.githubapp.GitHubEvent;
+import io.quarkiverse.githubapp.runtime.SimpleGitHubEvent;
 import io.quarkus.arc.Arc;
 import io.quarkus.runtime.LaunchMode;
 import io.vertx.core.json.Json;
@@ -33,7 +34,7 @@ public interface GitHubEventPreprocessor {
 
     static GitHubEvent updatePayload(GitHubEvent event, JsonNode payload) {
         String payloadJson = payload.toPrettyString();
-        return new GitHubEvent(event.getInstallationId(),
+        return new SimpleGitHubEvent(event.getInstallationId(),
                 event.getAppName().orElse(null), event.getDeliveryId(), event.getRepositoryOrThrow(),
                 event.getEvent(), event.getAction(), payloadJson, (JsonObject) Json.decodeValue(payloadJson),
                 event.isReplayed());

--- a/src/test/java/org/wildfly/bot/StartupEventTest.java
+++ b/src/test/java/org/wildfly/bot/StartupEventTest.java
@@ -11,7 +11,7 @@ import io.quarkus.runtime.StartupEvent;
 import io.quarkus.test.InMemoryLogHandler;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestExtension;
+
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import org.jboss.logmanager.Level;
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+
 import org.kohsuke.github.GHApp;
 import org.kohsuke.github.GHAppInstallation;
 import org.kohsuke.github.GHAuthenticatedAppInstallation;
@@ -28,7 +28,6 @@ import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.HttpException;
 import org.kohsuke.github.PagedIterable;
-import org.kohsuke.github.PagedIterator;
 import org.kohsuke.github.PagedSearchIterable;
 import org.wildfly.bot.model.RuntimeConstants;
 import org.wildfly.bot.utils.TestConstants;
@@ -44,7 +43,7 @@ import java.util.function.Consumer;
 import java.util.logging.LogManager;
 
 import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
-import static org.mockito.ArgumentMatchers.anyInt;
+
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -85,9 +84,6 @@ public class StartupEventTest {
 
     private Mockable mockedContext;
 
-    @RegisterExtension
-    static QuarkusTestExtension TEST = new QuarkusTestExtension();
-
     @BeforeEach
     void setup() {
         mockedContext = MockedGHPullRequest.builder(1371642823);
@@ -120,13 +116,12 @@ public class StartupEventTest {
                     mocks.ghObject(GHAppInstallation.class, 0L));
             GHAppInstallation mockGHAppInstallation = mock(GHAppInstallation.class);
             GHAuthenticatedAppInstallation mockGHAuthenticatedAppInstallation = mock(GHAuthenticatedAppInstallation.class);
-            PagedSearchIterable<GHRepository> mockGHRepositories = mock(PagedSearchIterable.class);
-            PagedIterator<GHRepository> mockIterator = mock(PagedIterator.class);
             if (configFile != null) {
                 mocks.configFile(RuntimeConstants.CONFIG_FILE_NAME).fromString(configFile);
             }
 
             GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
+            PagedSearchIterable<GHRepository> mockGHRepositories = GitHubAppMockito.mockPagedIterable(repo);
 
             when(clientProvider.getApplicationClient()).thenReturn(mockGitHub);
             when(mockGitHub.getApp()).thenReturn(mockGHApp);
@@ -140,10 +135,6 @@ public class StartupEventTest {
             }
             when(mockGitHub.getInstallation()).thenReturn(mockGHAuthenticatedAppInstallation);
             when(mockGHAuthenticatedAppInstallation.listRepositories()).thenReturn(mockGHRepositories);
-
-            when(mockGHRepositories._iterator(anyInt())).thenReturn(mockIterator);
-            when(mockIterator.next()).thenReturn(repo);
-            when(mockIterator.hasNext()).thenReturn(true).thenReturn(false);
 
             mockedContext.mock(mocks);
 

--- a/src/test/java/org/wildfly/bot/utils/mocking/Mockable.java
+++ b/src/test/java/org/wildfly/bot/utils/mocking/Mockable.java
@@ -1,6 +1,5 @@
 package org.wildfly.bot.utils.mocking;
 
-import com.thoughtworks.xstream.InitializationException;
 import io.quarkiverse.githubapp.testing.dsl.GitHubMockContext;
 import org.wildfly.bot.utils.TestConstants;
 import org.wildfly.bot.utils.model.SsePullRequestPayload;
@@ -40,13 +39,14 @@ public abstract class Mockable {
                     .build();
             requiredMockableCollector.add(MockedGHPullRequest.builder(ssePullRequestPayload.id()));
         } catch (IOException e) {
-            throw new InitializationException("Unable to initialize MockedGHPullRequest", e);
+            throw new RuntimeException("Unable to initialize MockedGHPullRequest", e);
         }
         requiredMockables = Collections.unmodifiableSet(requiredMockableCollector);
     }
     private static final Set<Mockable> executedMockables = new HashSet<>();
 
     public final void mock(GitHubMockContext mocks) throws IOException {
+        executedMockables.clear();
         this.mockNext(mocks, new AtomicLong());
     }
 

--- a/src/test/java/org/wildfly/bot/utils/testing/internal/TestModel.java
+++ b/src/test/java/org/wildfly/bot/utils/testing/internal/TestModel.java
@@ -50,6 +50,8 @@ public class TestModel implements QuarkusTestBeforeEachCallback, QuarkusTestAfte
     }
 
     public static PullRequestJson defaultBeforeEachJsons() throws Exception {
+        pullRequestJsonBuilderFunction = builder -> builder;
+        pullRequestJson = null;
         setJsons(
                 () -> SsePullRequestPayload.builder(TestConstants.VALID_PR_TEMPLATE_JSON),
                 PullRequestGitHubEventPayload::new);

--- a/src/test/java/org/wildfly/bot/utils/testing/reflection/ExposeGitHubAppTestingContext.java
+++ b/src/test/java/org/wildfly/bot/utils/testing/reflection/ExposeGitHubAppTestingContext.java
@@ -54,7 +54,7 @@ public class ExposeGitHubAppTestingContext {
 
     public static void initEventStubs(GitHubAppTestingContext testingContext, long installationId)
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Method privateMethod = GitHubMockContextImpl.class.getDeclaredMethod("initEventStubs", long.class);
+        Method privateMethod = GitHubMockContextImpl.class.getDeclaredMethod("initEventStubs", Long.class);
 
         privateMethod.setAccessible(true);
         privateMethod.invoke(testingContext.mocks, installationId);


### PR DESCRIPTION
Fixes #240 
Updated Quarkus platform 3.9.2 -> 3.34.2 and quarkus-github-app 2.5.1 -> 2.14.0 with the following breaking change "fixes":
  - pom.xml: Renamed JUnit artifacts (quarkus-junit5 -> quarkus-junit, etc.)
  - EventPollingProcessor / GitHubEventPreprocessor: GitHubEvent is now an interface -> use SimpleGitHubEvent
  - Mockable: Removed `com.thoughtworks.xstream` dependency (no longer transitive), added defensive executedMockables.clear()
  - LifecycleProcessor: Removed `@Any` qualifier to fix ambiguous CDI injection with generated Multiplexer bean; moved `@Installation.Suspend`/`@Installation.Unsuspend` handlers to new `InstallationObserver` class to prevent Multiplexer from
  duplicating the `@Observes` StartupEvent observer
  - StartupEventTest: Used GitHubAppMockito.mockPagedIterable() for proper iterator mocking, removed redundant @RegisterExtension
  - TestModel: Reset static state in defaultBeforeEachJsons() to fix ClassCast between test classes