### PR TITLE
Fix polling tests by disabling scheduler, as it is not needed in test…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,7 @@ quarkus.openshift.jvm-arguments=-Xmx128M
 quarkus.openshift.native-arguments=-Xmx128M
 quarkus.scheduler.enabled=false
 %polling.quarkus.scheduler.enabled=true
+%test.quarkus.scheduler.enabled=false
 
 
 %test.quarkus.github-app.app-id=0


### PR DESCRIPTION
…ing, but breaks other tests by firing.

fixes #243 