### PR TITLE
Prevent re-requesting submitted reviews on push

### DIFF
--- a/src/main/java/org/wildfly/bot/PullRequestRuleActivationProcessor.java
+++ b/src/main/java/org/wildfly/bot/PullRequestRuleActivationProcessor.java
@@ -44,7 +44,7 @@ public class PullRequestRuleActivationProcessor {
 
         GHRepository repository = pullRequest.getRepository();
         SequencedMap<String, List<String>> ccMentionsWithRules = new LinkedHashMap<>();
-        Set<String> reviewers = new HashSet<>();
+        Set<String> reviewersToBeRequested = new HashSet<>();
         Set<String> labels = new HashSet<>();
 
         for (WildFlyConfigFile.WildFlyRule rule : wildflyBotConfigFile.wildfly.rules) {
@@ -52,7 +52,7 @@ public class PullRequestRuleActivationProcessor {
                 if (!rule.notify.isEmpty()) {
                     logger.infof("title \"%s\" was matched with a rule, containing notify, with the id: %s.",
                             pullRequest.getTitle(), rule.id != null ? rule.id : "N/A");
-                    reviewers.addAll(rule.notify);
+                    reviewersToBeRequested.addAll(rule.notify);
                 }
                 labels.addAll(rule.labels);
             } else if (Matcher.notifyComment(pullRequest, rule)) {
@@ -67,7 +67,7 @@ public class PullRequestRuleActivationProcessor {
         }
 
         ccMentionsWithRules.remove(pullRequest.getUser().getLogin());
-        reviewers.remove(pullRequest.getUser().getLogin());
+        reviewersToBeRequested.remove(pullRequest.getUser().getLogin());
 
         githubProcessor.createLabelsIfMissing(repository, labels);
 
@@ -81,7 +81,7 @@ public class PullRequestRuleActivationProcessor {
             pullRequest.addLabels(labels.toArray(String[]::new));
         }
 
-        githubProcessor.processNotifies(pullRequest, gitHub, ccMentionsWithRules, reviewers,
+        githubProcessor.processNotifies(pullRequest, gitHub, ccMentionsWithRules, reviewersToBeRequested,
                 wildflyBotConfigFile.wildfly.emails);
     }
 

--- a/src/main/java/org/wildfly/bot/util/GithubProcessor.java
+++ b/src/main/java/org/wildfly/bot/util/GithubProcessor.java
@@ -12,6 +12,7 @@ import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHPerson;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestCommitDetail;
+import org.kohsuke.github.GHPullRequestReview;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
@@ -86,35 +87,40 @@ public class GithubProcessor {
     }
 
     public void processNotifies(GHPullRequest pullRequest, GitHub gitHub,
-            SequencedMap<String, List<String>> ccMentionsWithRules, Set<String> reviewers,
+            SequencedMap<String, List<String>> ccMentionsWithRules, Set<String> reviewersToBeRequested,
             List<String> emails) throws IOException {
-        if (ccMentionsWithRules.isEmpty() && reviewers.isEmpty()) {
+        if (ccMentionsWithRules.isEmpty() && reviewersToBeRequested.isEmpty()) {
             updateCCMentions(pullRequest, new LinkedHashMap<>());
             return;
         }
 
-        reviewers.forEach(ccMentionsWithRules::remove);
+        reviewersToBeRequested.forEach(ccMentionsWithRules::remove);
 
-        List<String> currentReviewers = pullRequest.getRequestedReviewers()
-                .stream()
+        // pending reviewers
+        Set<String> existingReviewers = pullRequest.getRequestedReviewers().stream()
                 .map(GHPerson::getLogin)
-                .toList();
+                .collect(Collectors.toSet());
 
-        logger.infof("Current reviewers already added to the PR: %s", currentReviewers);
+        // reviewers who have already submitted a review (non-pending reviewers)
+        for (GHPullRequestReview review : pullRequest.listReviews()) {
+            existingReviewers.add(review.getUser().getLogin());
+        }
 
-        currentReviewers.forEach(reviewers::remove);
+        logger.infof("Existing reviewers (pending and submitted): %s", existingReviewers);
 
-        logger.infof("Reviewers to be added to the PR: %s", reviewers);
+        reviewersToBeRequested.removeAll(existingReviewers);
+
+        logger.infof("Reviewers to be added to the PR: %s", reviewersToBeRequested);
 
         updateCCMentions(pullRequest, ccMentionsWithRules);
 
-        if (!reviewers.isEmpty()) {
+        if (!reviewersToBeRequested.isEmpty()) {
             if (wildFlyBotConfig.isDryRun()) {
                 logger.infof(RuntimeConstants.DRY_RUN_PREPEND.formatted("PR review requested from \"%s\""),
-                        String.join(",", reviewers));
+                        String.join(",", reviewersToBeRequested));
             } else {
                 List<String> failedReviewers = new ArrayList<>();
-                for (String requestedReviewer : reviewers) {
+                for (String requestedReviewer : reviewersToBeRequested) {
                     try {
                         GHUser ghUser = gitHub.getUser(requestedReviewer);
                         pullRequest.requestReviewers(List.of(ghUser));

--- a/src/test/java/org/wildfly/bot/PRNotifyChangeOnPREditTest.java
+++ b/src/test/java/org/wildfly/bot/PRNotifyChangeOnPREditTest.java
@@ -60,7 +60,7 @@ public class PRNotifyChangeOnPREditTest {
         mockedContext = MockedGHPullRequest.builder(pullRequestJson.id())
                 .commit("WFLY-123 commit")
                 .files("src/pom.xml", "app/pom.xml")
-                .reviewers("Tadpole")
+                .pendingReviewers("Tadpole")
                 .mockNext(MockedGHRepository.builder())
                 .users("Tadpole", "Butterfly");
 
@@ -96,7 +96,7 @@ public class PRNotifyChangeOnPREditTest {
                 .comment("/cc @Duke [WFLY]", botContextProvider.getBotName())
                 .commit("WFLY-123 commit")
                 .files("src/pom.xml", "app/pom.xml")
-                .reviewers("Tadpole")
+                .pendingReviewers("Tadpole")
                 .mockNext(MockedGHRepository.builder())
                 .users("Tadpole", "Butterfly");
 
@@ -131,7 +131,7 @@ public class PRNotifyChangeOnPREditTest {
         mockedContext = MockedGHPullRequest.builder(pullRequestJson.id())
                 .commit("WFLY-123 commit")
                 .files("src/pom.xml", "app/pom.xml")
-                .reviewers("Tadpole")
+                .pendingReviewers("Tadpole")
                 .mockNext(MockedGHRepository.builder())
                 .users("Tadpole", "Butterfly");
 
@@ -190,7 +190,7 @@ public class PRNotifyChangeOnPREditTest {
         mockedContext = MockedGHPullRequest.builder(pullRequestJson.id())
                 .commit("WFLY-123 commit")
                 .files("src/pom.xml", "app/pom.xml")
-                .reviewers("Tadpole", "Butterfly")
+                .pendingReviewers("Tadpole", "Butterfly")
                 .mockNext(MockedGHRepository.builder())
                 .users("Tadpole", "Butterfly");
 
@@ -201,5 +201,90 @@ public class PRNotifyChangeOnPREditTest {
                     Mockito.verify(mocks.pullRequest(pullRequestJson.id())).comment("/cc @Duke [test2]");
                     Mockito.verify(mocks.pullRequest(pullRequestJson.id()), Mockito.never()).requestReviewers(anyList());
                 });
+    }
+
+    @Test
+    public void testReviewerWhoSubmittedReviewIsExcluded() throws Throwable {
+        wildflyConfigFile = """
+                wildfly:
+                  rules:
+                    - id: "test"
+                      directories: [src]
+                      notify: [Tadpole]""";
+
+        mockedContext = MockedGHPullRequest.builder(pullRequestJson.id())
+                .commit("WFLY-123 commit")
+                .files("src/pom.xml")
+                .submittedReviewers("Tadpole")
+                .mockNext(MockedGHRepository.builder())
+                .users("Tadpole");
+
+        TestModel.given(
+                mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson, mockedContext))
+                .pullRequestEvent(pullRequestJson)
+                // reviewer already submitted their review, no need for the bot to request it
+                // again
+                .then(mocks -> Mockito.verify(mocks.pullRequest(pullRequestJson.id()), Mockito.never())
+                        .requestReviewers(anyList()));
+    }
+
+    @Test
+    public void testReviewerWhoSubmittedReviewIsExcludedNewReviewerAdded() throws Throwable {
+        wildflyConfigFile = """
+                wildfly:
+                  rules:
+                    - id: "test"
+                      directories: [src]
+                      notify: [Tadpole]
+
+                    - id: "test2"
+                      directories: [app]
+                      notify: [Butterfly]""";
+
+        mockedContext = MockedGHPullRequest.builder(pullRequestJson.id())
+                .commit("WFLY-123 commit")
+                .files("src/pom.xml", "app/pom.xml")
+                .submittedReviewers("Tadpole")
+                .mockNext(MockedGHRepository.builder())
+                .users("Tadpole", "Butterfly");
+
+        TestModel.given(
+                mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson, mockedContext))
+                .pullRequestEvent(pullRequestJson)
+                .then(mocks -> {
+                    ArgumentCaptor<List<GHUser>> captor = ArgumentCaptor.forClass(List.class);
+                    // first reviewer (Tadpole) already submitted their review
+                    // after a force push, commit now contains changes in the app directory, so the
+                    // bot should request a review from Butterfly
+                    Mockito.verify(mocks.pullRequest(pullRequestJson.id())).requestReviewers(captor.capture());
+                    Assertions.assertEquals(1, captor.getValue().size());
+                    MatcherAssert.assertThat(captor.getValue().stream()
+                            .map(GHPerson::getLogin)
+                            .toList(), Matchers.containsInAnyOrder("Butterfly"));
+                });
+    }
+
+    @Test
+    public void testReviewerWhoSubmittedReviewIsExcludedPendingReviewerNotDuplicated() throws Throwable {
+        wildflyConfigFile = """
+                wildfly:
+                  rules:
+                    - id: "test"
+                      directories: [src]
+                      notify: [Tadpole, Butterfly]""";
+
+        mockedContext = MockedGHPullRequest.builder(pullRequestJson.id())
+                .commit("WFLY-123 commit")
+                .files("src/pom.xml")
+                .submittedReviewers("Tadpole")
+                .pendingReviewers("Butterfly")
+                .mockNext(MockedGHRepository.builder())
+                .users("Tadpole", "Butterfly");
+
+        TestModel.given(
+                mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson, mockedContext))
+                .pullRequestEvent(pullRequestJson)
+                .then(mocks -> Mockito.verify(mocks.pullRequest(pullRequestJson.id()), Mockito.never())
+                        .requestReviewers(anyList()));
     }
 }

--- a/src/test/java/org/wildfly/bot/utils/mocking/MockedGHPullRequest.java
+++ b/src/test/java/org/wildfly/bot/utils/mocking/MockedGHPullRequest.java
@@ -8,6 +8,7 @@ import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestCommitDetail;
 import org.kohsuke.github.GHPullRequestFileDetail;
+import org.kohsuke.github.GHPullRequestReview;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.PagedSearchIterable;
 import org.mockito.Mockito;
@@ -19,6 +20,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -28,7 +30,10 @@ public class MockedGHPullRequest extends Mockable {
     private Set<String> prFiles = new LinkedHashSet<>();
     private String description;
     private final List<Tuple2<String, String>> comments = new ArrayList<>();
-    private Set<String> reviewers = new LinkedHashSet<>();
+
+    private final SequencedSet<String> pendingReviewers = new LinkedHashSet<>();
+    private final SequencedSet<String> reviewersWhoSubmittedReview = new LinkedHashSet<>();
+
     private Set<String> prLabels = new LinkedHashSet<>();
     private final List<MockedCommit> commits = new ArrayList<>();
     private Boolean mergeable = Boolean.TRUE;
@@ -88,8 +93,13 @@ public class MockedGHPullRequest extends Mockable {
         return this;
     }
 
-    public MockedGHPullRequest reviewers(String... reviewers) {
-        this.reviewers.addAll(Arrays.asList(reviewers));
+    public MockedGHPullRequest pendingReviewers(String... reviewerLogins) {
+        this.pendingReviewers.addAll(Arrays.asList(reviewerLogins));
+        return this;
+    }
+
+    public MockedGHPullRequest submittedReviewers(String... reviewerLogins) {
+        this.reviewersWhoSubmittedReview.addAll(Arrays.asList(reviewerLogins));
         return this;
     }
 
@@ -156,12 +166,24 @@ public class MockedGHPullRequest extends Mockable {
         Mockito.when(pullRequest.listCommits()).thenReturn(commitDetails);
 
         List<GHUser> requestedReviewers = new ArrayList<>();
-        for (String reviewer : reviewers) {
+        for (String reviewer : pendingReviewers) {
             GHUser user = mocks.ghObject(GHUser.class, idGenerator.incrementAndGet());
             Mockito.when(user.getLogin()).thenReturn(reviewer);
             requestedReviewers.add(user);
         }
         Mockito.when(pullRequest.getRequestedReviewers()).thenReturn(requestedReviewers);
+
+        List<GHPullRequestReview> mockedReviews = new ArrayList<>();
+        for (String reviewerLogin : reviewersWhoSubmittedReview) {
+            GHPullRequestReview review = Mockito.mock(GHPullRequestReview.class);
+            GHUser reviewUser = mocks.ghObject(GHUser.class, idGenerator.incrementAndGet());
+            Mockito.when(reviewUser.getLogin()).thenReturn(reviewerLogin);
+            Mockito.when(review.getUser()).thenReturn(reviewUser);
+            mockedReviews.add(review);
+        }
+        PagedSearchIterable<GHPullRequestReview> reviewsIterable = GitHubAppMockito
+                .mockPagedIterable(mockedReviews.toArray(GHPullRequestReview[]::new));
+        Mockito.when(pullRequest.listReviews()).thenReturn(reviewsIterable);
 
         Collection<GHLabel> pullRequestLabels = new ArrayList<>();
         for (String label : this.prLabels) {


### PR DESCRIPTION
[#wildfly-developers > WildFly bot – clears existing reviews on push](https://wildfly.zulipchat.com/#narrow/channel/174184-wildfly-developers/topic/WildFly.20bot.20.E2.80.93.20clears.20existing.20reviews.20on.20push/with/611329420)